### PR TITLE
Fix Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-download"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Running `cargo build` on a clean checkout produces a diff in Cargo.lock, because it wasn't updated after the version number was bumped.

After this commit, `cargo build` should no longer produce a modified working tree.